### PR TITLE
Fix technology handlers to use displayName

### DIFF
--- a/src/modules/technology/handlers/create-technology.spec.ts
+++ b/src/modules/technology/handlers/create-technology.spec.ts
@@ -7,9 +7,9 @@ jest.mock('../../../cache/cache', () => ({
 }));
 
 const MOCK_REQUEST: any = {
-	body: {
-		name: 'Jest',
-	},
+        body: {
+                displayName: 'Jest',
+        },
 };
 const MOCK_RESPONSE: any = {
 	status: jest.fn(),

--- a/src/modules/technology/handlers/update-technology.spec.ts
+++ b/src/modules/technology/handlers/update-technology.spec.ts
@@ -10,9 +10,9 @@ const MOCK_REQUEST: any = {
 	params: {
 		technologyId: '1',
 	},
-	body: {
-		name: 'Jest',
-	},
+        body: {
+                displayName: 'Jest',
+        },
 };
 const MOCK_RESPONSE: any = {
 	status: jest.fn(),

--- a/src/modules/technology/handlers/update-technology.ts
+++ b/src/modules/technology/handlers/update-technology.ts
@@ -11,10 +11,10 @@ export async function updateTechnology(
 	next: NextFunction
 ): Promise<void> {
 	const technologyId: number = parseInt(req.params.technologyId);
-	const updateResult = await updateTechnologyEntry(technologyId, {
-		displayName: req.body.name,
-		description: req.body.description,
-	});
+        const updateResult = await updateTechnologyEntry(technologyId, {
+                displayName: req.body.displayName,
+                description: req.body.description,
+        });
 
 	if (updateResult.type === Result.ERROR) {
 		LogHelper.error(updateResult.message, updateResult.error);


### PR DESCRIPTION
## Summary
- fix updateTechnology handler to read `displayName` from the request body
- update tests to use `displayName`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438fa259e88322978978b0ae50e151